### PR TITLE
add parrametr to cloudwatchevent_rule for support FARGATE on ecs

### DIFF
--- a/lib/ansible/modules/cloud/amazon/cloudwatchevent_rule.py
+++ b/lib/ansible/modules/cloud/amazon/cloudwatchevent_rule.py
@@ -66,7 +66,7 @@ options:
       - "A dictionary array of targets to add to or update for the rule, in the
         form C({ id: [string], arn: [string], role_arn: [string], input: [valid JSON string],
         input_path: [valid JSONPath string], ecs_parameters: {task_definition_arn: [string], task_count: [int],
-        launch_type: FARGATE|EC2, platform_version: "1.1.0", network_configuration: [dict] }}).
+        launch_type: choices ["FARGATE","EC2"], platform_version: [string ]"1.1.0", network_configuration: [dict] }}).
         I(id) [required] is the unique target assignment ID. I(arn) (required)
         is the Amazon Resource Name associated with the target. I(role_arn) (optional) is The Amazon Resource Name
         of the IAM role to be used for this target when the rule is triggered. I(input)
@@ -77,6 +77,9 @@ options:
         specified, then the entire event is passed to the target in JSON form.
         I(task_definition_arn) [optional] is ecs task definition arn.
         I(task_count) [optional] is ecs task count."
+        I(lanch_type) [optional] is ecs lanch_type.
+        I(platform_version) [requred] if ecs lanch_type choice FARGATE.
+        I(network_configuration) [requred] if ecs lanch_type choice FARGATE.
     required: false
 '''
 

--- a/lib/ansible/modules/cloud/amazon/cloudwatchevent_rule.py
+++ b/lib/ansible/modules/cloud/amazon/cloudwatchevent_rule.py
@@ -65,7 +65,8 @@ options:
     description:
       - "A dictionary array of targets to add to or update for the rule, in the
         form C({ id: [string], arn: [string], role_arn: [string], input: [valid JSON string],
-        input_path: [valid JSONPath string], ecs_parameters: {task_definition_arn: [string], task_count: [int]}}).
+        input_path: [valid JSONPath string], ecs_parameters: {task_definition_arn: [string], task_count: [int],
+        launch_type: FARGATE|EC2, platform_version: "1.1.0", network_configuration: [dict] }}).
         I(id) [required] is the unique target assignment ID. I(arn) (required)
         is the Amazon Resource Name associated with the target. I(role_arn) (optional) is The Amazon Resource Name
         of the IAM role to be used for this target when the rule is triggered. I(input)
@@ -275,6 +276,22 @@ class CloudWatchEventRule(object):
                     target_request['EcsParameters']['TaskDefinitionArn'] = ecs_parameters['task_definition_arn']
                 if 'task_count' in target['ecs_parameters']:
                     target_request['EcsParameters']['TaskCount'] = ecs_parameters['task_count']
+                if 'launch_type' in target['ecs_parameters']:
+                    target_request['EcsParameters']['LaunchType'] = ecs_parameters['launch_type']
+                if 'platform_version' in target['ecs_parameters']:
+                    target_request['EcsParameters']['PlatformVersion'] = ecs_parameters['platform_version']
+                if 'network_configuration' in target['ecs_parameters']:
+                    target_request['EcsParameters']['NetworkConfiguration'] = {}
+                    target_request['EcsParameters']['NetworkConfiguration']['awsvpcConfiguration'] = {} 
+                    network_configuration = ecs_parameters['network_configuration']['awsvpc_configuration']
+                    if 'subnets' in network_configuration:
+                        target_request['EcsParameters']['NetworkConfiguration']['awsvpcConfiguration']['Subnets'] = network_configuration['subnets']
+                    if 'security_groups' in network_configuration:
+                        target_request['EcsParameters']['NetworkConfiguration']['awsvpcConfiguration']['SecurityGroups'] = network_configuration['security_groups']
+                    if 'assign_public_ip' in network_configuration:
+                        target_request['EcsParameters']['NetworkConfiguration']['awsvpcConfiguration']['AssignPublicIp'] = network_configuration['assign_public_ip']
+
+
             targets_request.append(target_request)
         return targets_request
 

--- a/lib/ansible/modules/cloud/amazon/cloudwatchevent_rule.py
+++ b/lib/ansible/modules/cloud/amazon/cloudwatchevent_rule.py
@@ -285,11 +285,14 @@ class CloudWatchEventRule(object):
                     target_request['EcsParameters']['NetworkConfiguration']['awsvpcConfiguration'] = {} 
                     network_configuration = ecs_parameters['network_configuration']['awsvpc_configuration']
                     if 'subnets' in network_configuration:
-                        target_request['EcsParameters']['NetworkConfiguration']['awsvpcConfiguration']['Subnets'] = network_configuration['subnets']
+                        target_request['EcsParameters']['NetworkConfiguration']['awsvpcConfiguration']['Subnets'] = \
+                        network_configuration['subnets']
                     if 'security_groups' in network_configuration:
-                        target_request['EcsParameters']['NetworkConfiguration']['awsvpcConfiguration']['SecurityGroups'] = network_configuration['security_groups']
+                        target_request['EcsParameters']['NetworkConfiguration']['awsvpcConfiguration']['SecurityGroups'] = \
+                        network_configuration['security_groups']
                     if 'assign_public_ip' in network_configuration:
-                        target_request['EcsParameters']['NetworkConfiguration']['awsvpcConfiguration']['AssignPublicIp'] = network_configuration['assign_public_ip']
+                        target_request['EcsParameters']['NetworkConfiguration']['awsvpcConfiguration']['AssignPublicIp'] = \
+                        network_configuration['assign_public_ip']
 
 
             targets_request.append(target_request)

--- a/lib/ansible/modules/cloud/amazon/cloudwatchevent_rule.py
+++ b/lib/ansible/modules/cloud/amazon/cloudwatchevent_rule.py
@@ -66,7 +66,7 @@ options:
       - "A dictionary array of targets to add to or update for the rule, in the
         form C({ id: [string], arn: [string], role_arn: [string], input: [valid JSON string],
         input_path: [valid JSONPath string], ecs_parameters: {task_definition_arn: [string], task_count: [int],
-        launch_type: choices ['FARGATE','EC2'], platform_version: [string ]"1.1.0", network_configuration: [dict] }}).
+        launch_type: choices [FARGATE,EC2], platform_version: choices[1.1.0,1.2.0], network_configuration: [dict] }}).
         I(id) [required] is the unique target assignment ID. I(arn) (required)
         is the Amazon Resource Name associated with the target. I(role_arn) (optional) is The Amazon Resource Name
         of the IAM role to be used for this target when the rule is triggered. I(input)
@@ -289,14 +289,13 @@ class CloudWatchEventRule(object):
                     network_configuration = ecs_parameters['network_configuration']['awsvpc_configuration']
                     if 'subnets' in network_configuration:
                         target_request['EcsParameters']['NetworkConfiguration']['awsvpcConfiguration']['Subnets'] = \
-                        network_configuration['subnets']
+                            network_configuration['subnets']
                     if 'security_groups' in network_configuration:
                         target_request['EcsParameters']['NetworkConfiguration']['awsvpcConfiguration']['SecurityGroups'] = \
-                        network_configuration['security_groups']
+                            network_configuration['security_groups']
                     if 'assign_public_ip' in network_configuration:
                         target_request['EcsParameters']['NetworkConfiguration']['awsvpcConfiguration']['AssignPublicIp'] = \
-                        network_configuration['assign_public_ip']
-
+                            network_configuration['assign_public_ip']
 
             targets_request.append(target_request)
         return targets_request

--- a/lib/ansible/modules/cloud/amazon/cloudwatchevent_rule.py
+++ b/lib/ansible/modules/cloud/amazon/cloudwatchevent_rule.py
@@ -66,7 +66,7 @@ options:
       - "A dictionary array of targets to add to or update for the rule, in the
         form C({ id: [string], arn: [string], role_arn: [string], input: [valid JSON string],
         input_path: [valid JSONPath string], ecs_parameters: {task_definition_arn: [string], task_count: [int],
-        launch_type: choices ["FARGATE","EC2"], platform_version: [string ]"1.1.0", network_configuration: [dict] }}).
+        launch_type: choices ['FARGATE','EC2'], platform_version: [string ]"1.1.0", network_configuration: [dict] }}).
         I(id) [required] is the unique target assignment ID. I(arn) (required)
         is the Amazon Resource Name associated with the target. I(role_arn) (optional) is The Amazon Resource Name
         of the IAM role to be used for this target when the rule is triggered. I(input)
@@ -76,10 +76,10 @@ options:
         passed to the target. If neither I(input) nor I(input_path) is
         specified, then the entire event is passed to the target in JSON form.
         I(task_definition_arn) [optional] is ecs task definition arn.
-        I(task_count) [optional] is ecs task count."
+        I(task_count) [optional] is ecs task count.
         I(lanch_type) [optional] is ecs lanch_type.
         I(platform_version) [requred] if ecs lanch_type choice FARGATE.
-        I(network_configuration) [requred] if ecs lanch_type choice FARGATE.
+        I(network_configuration) [requred] if ecs lanch_type choice FARGATE."
     required: false
 '''
 
@@ -285,7 +285,7 @@ class CloudWatchEventRule(object):
                     target_request['EcsParameters']['PlatformVersion'] = ecs_parameters['platform_version']
                 if 'network_configuration' in target['ecs_parameters']:
                     target_request['EcsParameters']['NetworkConfiguration'] = {}
-                    target_request['EcsParameters']['NetworkConfiguration']['awsvpcConfiguration'] = {} 
+                    target_request['EcsParameters']['NetworkConfiguration']['awsvpcConfiguration'] = {}
                     network_configuration = ecs_parameters['network_configuration']['awsvpc_configuration']
                     if 'subnets' in network_configuration:
                         target_request['EcsParameters']['NetworkConfiguration']['awsvpcConfiguration']['Subnets'] = \


### PR DESCRIPTION
##### SUMMARY
add parrametr to cloudwatchevent_rule for support FARGATE on ecs

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
cloudwatchevent_rule

##### ANSIBLE VERSION

```ansible 2.7.1
  config file = None
  configured module search path = ['/home/bart/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/bart/ansible/lib/python3.6/site-packages/ansible
  executable location = /home/bart/ansible/bin/ansible
  python version = 3.6.6 (default, Sep 12 2018, 18:26:19) [GCC 8.0.1 20180414 (experimental) [trunk revision 259383]]
```

